### PR TITLE
Added snippets for CC-licensed pages

### DIFF
--- a/pears/indexer/detect_open.py
+++ b/pears/indexer/detect_open.py
@@ -1,0 +1,48 @@
+#Detect whether page is under CC license and a snippet can be extracted from it.
+
+from bs4 import BeautifulSoup
+import requests
+import sys
+import re
+
+
+def open_site(url):
+  '''Checking for wikipedia or SO page'''
+  for i in ["wikipedia.org","stackoverflow.com"]:
+    if i in url:
+      return True
+  return False
+
+def cc(bs_obj):
+  '''Checking for CC logo'''
+  imgs = bs_obj.find_all('img')
+  for img in imgs:
+    src = img['src']
+    for i in ["creativecommons.org","cc-by"]:
+      if i in src:
+        return True
+  return False
+
+def get_snippet(bs_obj):
+  body = bs_obj.get_text()
+  pattern = re.compile('(^[\s]+)|([\s]+$)|([\s][\s]+)', re.MULTILINE)
+  body_str=re.sub(pattern," ",body)
+  i=0
+  snippet = ""
+  for l in body_str.split('\n'):
+    '''Only choose informative lines, not first in Wikipedia'''
+    if len(l) > 100 and i < 2 and "Jump to:" not in l and "XOWA" not in l:
+      snippet+=l.rstrip('\n')
+      i+=1
+  snippet = ' '.join(snippet.split(' ')[:50])
+  return snippet
+
+def try_snippet(url, bs_obj):
+  '''If page is CC-licensed, get snippet'''
+  snippet = ""
+  is_open = False
+
+  if open_site(url) or cc(bs_obj):
+    snippet = get_snippet(bs_obj)
+
+  return snippet

--- a/pears/indexer/runDistSemWeighted.py
+++ b/pears/indexer/runDistSemWeighted.py
@@ -74,7 +74,10 @@ def runScript():
         buff = l.body
         v = weightFile(buff)
         s,wordcloud = mkVector(v, dm_dict)
-        l.wordclouds = wordcloud
+        if l.wordclouds == "":
+          l.wordclouds = "WORDCLOUD: "+wordcloud
+        else:
+          l.wordclouds = "SNIPPET: "+l.wordclouds
         l.dists = s
         l.body = unicode("--processed--")
     db.session.commit()

--- a/pears/scorePages.py
+++ b/pears/scorePages.py
@@ -18,7 +18,7 @@ from .utils import query_distribution, cosine_similarity, print_timing
 from .models import Urls
 import cStringIO
 
-
+@print_timing
 def scoreDS(query_dist, pear_urls):
     """ Get distributional score """
     DS_scores = {}
@@ -50,6 +50,7 @@ def scoreURL(query, pear_urls):
     return URL_scores
 
 
+@print_timing
 def scoreDocs(query, query_dist, pear_urls):
     """ Score documents for a pear """
     document_scores = {}  # Document scores
@@ -103,7 +104,7 @@ def output(best_urls, url_titles, url_wordclouds):
         results = []
     return results
 
-
+@print_timing
 def get_pear_urls(ip):
     my_ip = ipgetter.myip()
     if ip == my_ip:


### PR DESCRIPTION
So here's a slight modification to the indexer, so that we get snippets for the CC-licensed pages. The code checks whether the page is CC (Wikipedia, SO, contains a CC logo?) If so, it extracts a snippet from it. Otherwise, we stick to our good old wordclouds. Snippets are of course nicer...