### PR TITLE
Fixing offline browsing with use of ip.42.pl

### DIFF
--- a/pears/scorePages.py
+++ b/pears/scorePages.py
@@ -106,7 +106,10 @@ def output(best_urls, url_titles, url_wordclouds):
 
 @print_timing
 def get_pear_urls(ip):
-    my_ip = urllib.urlopen('http://ip.42.pl/short').read().strip('\n')
+    try:
+        my_ip = urllib.urlopen('http://ip.42.pl/short').read().strip('\n')
+    except:
+        my_ip = "0.0.0.0"
     if ip == my_ip:
         urls = Urls.query.all()
         return [u.__dict__ for u in urls]

--- a/pears/searcher/views.py
+++ b/pears/searcher/views.py
@@ -63,8 +63,10 @@ def index():
           pears = ['no pear found :(']
           scorePages.ddg_redirect(query)
         elif not pears:
-            pears = [urllib.urlopen(
-                'http://ip.42.pl/short').read().strip('\n')]
+            try:
+              pears = [urllib.urlopen('http://ip.42.pl/short').read().strip('\n')]
+            except:
+              pears = ['0.0.0.0']
         # '''remove the following lines after testing'''
         # pages = [['http://test.com', 'test']]
 

--- a/pears/utils.py
+++ b/pears/utils.py
@@ -106,7 +106,10 @@ def query_distribution(query, entropies):
 
 def read_pears(pears):
     profile = Profile.query.first()
-    my_ip = urllib.urlopen('http://ip.42.pl/short').read().strip('\n')
+    try:
+        my_ip = urllib.urlopen('http://ip.42.pl/short').read().strip('\n')
+    except:
+        my_ip = "0.0.0.0"
     pears_dict = {}
     if not pears:
         p = profile.vector


### PR DESCRIPTION
We're using a web url to retrieve the local IP, and this is not compatible with offline browsing. Fixed by putting the call to ip.42.pl in a try statement and otherwise setting my_ip to 0.0.0.0.