### PR TITLE
Fix duplicates after indexing

### DIFF
--- a/indexer.py
+++ b/indexer.py
@@ -13,7 +13,7 @@ Options:
 --cache       Cache the text of each indexed page for offline browsing
 """
 
-from pears.indexer import retrieve_raw_data,hierarchClustering,mkLocalProfile
+from pears.indexer import retrieve_raw_data,hierarchClustering,mkLocalProfile,clean
 from docopt import docopt
 import os, sys
 
@@ -36,3 +36,4 @@ if __name__=="__main__":
       hierarchClustering.runScript(0.7)
 
   mkLocalProfile.runScript()
+  clean.runScript()

--- a/pears/indexer/caching.py
+++ b/pears/indexer/caching.py
@@ -12,7 +12,7 @@ from urlparse import urlparse, urljoin
 root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
 
 def write_html_to_cache(html, cached_page):
-  print "Writing to",cached_page,"..."
+  #print "Writing to",cached_page,"..."
   cache = codecs.open(cached_page,'w', encoding='utf8')
   html = html.replace('</head>','<link rel="stylesheet" type="text/css" href="'+root_dir+'/static/css/offline.css"/>\n</head>')
   cache.write(unicode(html))
@@ -36,18 +36,21 @@ def cache_file(url,html):
 
 def cache_pdf(url):
   '''Write pdf in local cache directory'''
-  url_parsed = urlparse(url)
-  path_dirs = url_parsed.path.rstrip('/')[1:].split('/')
-  page = path_dirs[-1]
-  cached_netloc = "./html_cache/"+url_parsed.netloc
-  cached_dir = cached_netloc+"/"+'/'.join(path_dirs[:-1])+"/"
-  if not os.path.isdir(cached_dir):
-    os.makedirs(cached_dir)
-  cached_page = cached_dir+page
-  if not os.path.exists(cached_page):
-    response = requests.get(url)
-    with open(cached_page, 'wb') as f:
-      f.write(response.content)
+  try:
+    url_parsed = urlparse(url)
+    path_dirs = url_parsed.path.rstrip('/')[1:].split('/')
+    page = path_dirs[-1]
+    cached_netloc = "./html_cache/"+url_parsed.netloc
+    cached_dir = cached_netloc+"/"+'/'.join(path_dirs[:-1])+"/"
+    if not os.path.isdir(cached_dir):
+      os.makedirs(cached_dir)
+    cached_page = cached_dir+page
+    if not os.path.exists(cached_page):
+      response = requests.get(url)
+      with open(cached_page, 'wb') as f:
+        f.write(response.content)
+  except:
+    print "Error caching the pdf..."
 
 
 def get_images(url):

--- a/pears/indexer/clean.py
+++ b/pears/indexer/clean.py
@@ -33,7 +33,7 @@ def list_duplicates(urls):
     for url2 in urls:
       if url2 != url1:
         u2 = url2.url
-        if u1 != "" and u2 != "":
+        if u1 != "" and u2 != "" and u1 != u2:
           if generic_overlap(u1,u2) > 0.9:
             print "Possible duplicates:",u1,u2
             to_remove = select_url(url1,url2)
@@ -57,6 +57,20 @@ def remove_duplicates():
     print "Deleting",u.url,"..."
     Urls.query.filter_by(url=u.url).delete()
     db.session.commit()
+
+
+def clean_cache():
+  cached_files = [os.path.join(dp, f) for dp, dn, filenames in os.walk("./html_cache/") for f in filenames]
+  for r in cached_files:
+    url1=r.replace("./html_cache","http:/")
+    url2=r.replace("./html_cache","https:/")
+    if not db.session.query(Urls).filter_by(url=url1).all() and not db.session.query(Urls).filter_by(url=url2).all():
+      print r,"is not in database! Deleting cached file..."
+      os.remove(r)
+    dir = re.sub("[^\/]*$","",r)
+    if not os.listdir(dir):
+      print dir,"is empty: removing directory..."
+      os.rmdir(dir)
 
 def runScript():
   print "Now cleaning up... removing duplicates..."

--- a/pears/indexer/clean.py
+++ b/pears/indexer/clean.py
@@ -1,0 +1,69 @@
+import math
+import os
+import re
+import sys
+
+import numpy as np
+from pears.overlap_calculation import generic_overlap
+from pears.models import Urls, OpenVectors
+from pears import app, db
+
+def select_url(url1,url2):
+  """For a pair of urls, choose the https if identical, shortest otherwise"""
+  remove = ""
+  u1 = url1.url
+  u2 = url2.url
+  if re.sub("https:","",u1) == re.sub("http:","",u2):
+    remove = url2
+  if re.sub("http:","",u1) == re.sub("https:","",u2):
+    remove = url1
+  if remove == "" and len(u1) < len(u2):
+    remove = url2
+  if remove == "" and len(u2) < len(u1):
+    remove = url1
+  if remove == "":
+    remove = url1
+  return remove
+
+
+def list_duplicates(urls):
+  duplicates = []
+  for url1 in urls:
+    u1 = url1.url
+    for url2 in urls:
+      if url2 != url1:
+        u2 = url2.url
+        if u1 != "" and u2 != "":
+          if generic_overlap(u1,u2) > 0.9:
+            print "Possible duplicates:",u1,u2
+            to_remove = select_url(url1,url2)
+            if to_remove not in duplicates:
+              duplicates.append(to_remove)
+    '''Checking there is still something left!'''
+    if len(duplicates) == len(urls):
+      del duplicates[-1]
+  return duplicates
+
+def remove_duplicates():
+  all_duplicates = []
+  urls = Urls.query.all()
+  for u in urls:
+    v = u.dists
+    matches = db.session.query(Urls).filter_by(dists=v).all()
+    if len(matches) > 1 :
+      all_duplicates.extend(list_duplicates(matches))
+      all_duplicates = list(set(all_duplicates))
+  for u in all_duplicates:
+    print "Deleting",u.url,"..."
+    Urls.query.filter_by(url=u.url).delete()
+    db.session.commit()
+
+def runScript():
+  print "Now cleaning up... removing duplicates..."
+  remove_duplicates()
+
+
+
+# when executing as script
+if __name__ == '__main__':
+    runScript() 

--- a/pears/indexer/clean.py
+++ b/pears/indexer/clean.py
@@ -27,18 +27,21 @@ def select_url(url1,url2):
 
 
 def list_duplicates(urls):
+  #print "Length of urls:",len(urls)
   duplicates = []
-  for url1 in urls:
-    u1 = url1.url
-    for url2 in urls:
-      if url2 != url1:
-        u2 = url2.url
-        if u1 != "" and u2 != "" and u1 != u2:
-          if generic_overlap(u1,u2) > 0.9:
-            print "Possible duplicates:",u1,u2
-            to_remove = select_url(url1,url2)
-            if to_remove not in duplicates:
-              duplicates.append(to_remove)
+  i=0
+  for i in range(len(urls)-1):
+    u1 = urls[i].url
+    j=0
+    for j in range(i+1,len(urls)):
+      u2 = urls[j].url
+      #print i,u1,j,u2
+      if u1 != "" and u2 != "" and u1 != u2:
+        if generic_overlap(u1,u2) > 0.9:
+          #print "Possible duplicates:",u1,u2
+          to_remove = select_url(urls[i],urls[j])
+          if to_remove not in duplicates:
+            duplicates.append(to_remove)
     '''Checking there is still something left!'''
     if len(duplicates) == len(urls):
       del duplicates[-1]
@@ -51,8 +54,10 @@ def remove_duplicates():
     v = u.dists
     matches = db.session.query(Urls).filter_by(dists=v).all()
     if len(matches) > 1 :
-      all_duplicates.extend(list_duplicates(matches))
-      all_duplicates = list(set(all_duplicates))
+      new_duplicates = list_duplicates(matches)
+      for n in new_duplicates:
+        if n not in all_duplicates:
+          all_duplicates.append(n)
   for u in all_duplicates:
     print "Deleting",u.url,"..."
     Urls.query.filter_by(url=u.url).delete()
@@ -62,22 +67,29 @@ def remove_duplicates():
 def clean_cache():
   cached_files = [os.path.join(dp, f) for dp, dn, filenames in os.walk("./html_cache/") for f in filenames]
   for r in cached_files:
-    url1=r.replace("./html_cache","http:/")
-    url2=r.replace("./html_cache","https:/")
+    '''Special case: url is dir and cached file is index.html'''
+    if "index.html" in r:
+      r=r.replace("index.html","")
+    url1=unicode(r.replace("./html_cache","http:/"))
+    url2=unicode(r.replace("./html_cache","https:/"))
     if not db.session.query(Urls).filter_by(url=url1).all() and not db.session.query(Urls).filter_by(url=url2).all():
       print r,"is not in database! Deleting cached file..."
-      os.remove(r)
+      try:
+        os.remove(r)
+      except:
+        print "Problem deleting..."
     dir = re.sub("[^\/]*$","",r)
     if not os.listdir(dir):
       print dir,"is empty: removing directory..."
       os.rmdir(dir)
 
 def runScript():
-  print "Now cleaning up... removing duplicates..."
+  print "\nNow cleaning up... removing duplicates..."
   remove_duplicates()
-
+  print "\nCleaning cache..."
+  clean_cache()
 
 
 # when executing as script
 if __name__ == '__main__':
-    runScript() 
+    runScript()

--- a/pears/indexer/htmlparser.py
+++ b/pears/indexer/htmlparser.py
@@ -16,21 +16,20 @@ def extract_from_url(url, cache):
     try:
       req = requests.get(unicode(url), allow_redirects=True, timeout=20)
     except (requests.exceptions.SSLError or requests.exceptions.Timeout) as e:
-      print "\nCaught the exception: {0}. Trying with http...\n".format(str(e))
+      #print "\nCaught the exception: {0}. Trying with http...\n".format(str(e))
       url = unicode(url.replace("https", "http"))
       req = requests.get(url, allow_redirects=True)
     except requests.exceptions.RequestException as e:
-      print "Ignoring {0} because of error {1}\n".format(url, str(e))
+      #print "Ignoring {0} because of error {1}\n".format(url, str(e))
+      print "Ignoring {0} because of error...\n".format(url)
       return
     except requests.exceptions.HTTPError as err:
-      print str(err)
+      #print str(err)
       return
     req.encoding = 'utf-8'
     if req.status_code is not 200:
       print "Warning: "  + str(req.url) + ' has a status code of: ' \
         + str(req.status_code) + ' omitted from database.\n'
-    if cache:
-      caching.runScript(url,unicode(req.text))
     bs_obj = BeautifulSoup(unicode(req.text),"lxml")
     if hasattr(bs_obj.title, 'string') & (req.status_code == requests.codes.ok):
       try:
@@ -57,9 +56,11 @@ def extract_from_url(url, cache):
       except None:
         title = u'Untitled'
         #print "Processed",url,"..."
+    if cache:
+      caching.runScript(url,unicode(req.text))
     return drows
     # can't connect to the host
   except:
     error = sys.exc_info()[0]
-    print "Error - %s" % error
+    #print "Error - %s" % error
 

--- a/pears/indexer/mkLocalProfile.py
+++ b/pears/indexer/mkLocalProfile.py
@@ -56,7 +56,7 @@ def computePearDist():
     # coh=0
     coh = coherence(vecs_for_coh)
     # print coh
-    return vbase, dist_str, coh
+    return vbase, unicode(dist_str), coh
 
 
 def createProfile(profile, pear_dist, topics_s, coh):
@@ -68,13 +68,15 @@ def createProfile(profile, pear_dist, topics_s, coh):
 
 
 def runScript():
-    print "Computing pear for local history..."
+    print "\nComputing pear for local history..."
     profile = Profile.query.first()
     if not profile:
         user = getpass.getuser()
         profile = Profile(name=unicode(user))
     v, print_v, coh = computePearDist()
-    topics, topics_s = sim_to_matrix(v, 20)
+    #For now, remove topics. They take too long to compute!
+    #topics, topics_s = sim_to_matrix(v, 20)
+    topics, topics_s = [], ""
     createProfile(profile, print_v, topics_s, coh)
 
 

--- a/pears/indexer/mkLocalProfile.py
+++ b/pears/indexer/mkLocalProfile.py
@@ -68,7 +68,6 @@ def createProfile(profile, pear_dist, topics_s, coh):
 
 
 def runScript():
-    #runDistSemWeighted.runScript()
     print "Computing pear for local history..."
     profile = Profile.query.first()
     if not profile:

--- a/pears/indexer/pdfparser.py
+++ b/pears/indexer/pdfparser.py
@@ -16,30 +16,30 @@ import sys
 def convert_pdf_to_txt(url):
   try:
     open = urllib2.urlopen(Request(url)).read()
+
+    memory_file = StringIO(open)
+    parser = PDFParser(memory_file)
+    document = PDFDocument(parser)
+
+    rsrcmgr = PDFResourceManager()
+    retstr = StringIO()
+    codec = 'utf-8'
+    laparams = LAParams()
+
+    device = TextConverter(rsrcmgr, retstr, codec=codec, laparams=laparams)
+
+    interpreter = PDFPageInterpreter(rsrcmgr, device)
+
+    for page in PDFPage.create_pages(document):
+      interpreter.process_page(page)
+
+    text = retstr.getvalue()
+
+    device.close()
+    retstr.close()
   except:
-    print "Error accessing the file"
+    print "Error accessing/parsing the PDF file"
     return ""
-
-  memory_file = StringIO(open)
-  parser = PDFParser(memory_file)
-  document = PDFDocument(parser)
-
-  rsrcmgr = PDFResourceManager()
-  retstr = StringIO()
-  codec = 'utf-8'
-  laparams = LAParams()
-
-  device = TextConverter(rsrcmgr, retstr, codec=codec, laparams=laparams)
-
-  interpreter = PDFPageInterpreter(rsrcmgr, device)
-
-  for page in PDFPage.create_pages(document):
-    interpreter.process_page(page)
-
-  text = retstr.getvalue()
-
-  device.close()
-  retstr.close()
   return text
 
 def extract_from_url(url, cache):

--- a/pears/indexer/retrieve_raw_data.py
+++ b/pears/indexer/retrieve_raw_data.py
@@ -86,7 +86,7 @@ def index_history(num_pages):
   cursor = firefox_db.cursor()
 
   # get the list of all visited places via firefox browser
-  cursor.execute("SELECT * FROM 'moz_places' ORDER BY visit_count DESC")
+  cursor.execute("SELECT * FROM 'moz_places' ORDER BY last_visit_date DESC")
   rows = cursor.fetchall()
 
   urls_to_process = record_urls_to_process(rows, int(num_pages))

--- a/pears/indexer/retrieve_raw_data.py
+++ b/pears/indexer/retrieve_raw_data.py
@@ -15,7 +15,8 @@ home_directory = os.path.expanduser('~')
 def mk_ignore():
     #A small ignore list for sites that don't need indexing.
     ignore=["twitter", "google", "duckduckgo", "bing", "yahoo", "facebook",
-            "mail.google.com", "whatsapp", "telegram"]
+            "mail.google.com", "whatsapp", "telegram", "0.0.0.5000",
+            "localhost"]
     '''Make ignore list'''
     s = []
     for i in ignore:
@@ -61,7 +62,7 @@ def record_urls_to_process(db_urls, num_pages):
                         url_with_www = url
                     if not db.session.query(Urls).filter_by(url=url).all():
                       urls_to_process.append(url)
-                      print "...writing",url,"..."
+                      #print "...writing",url,"to process..."
                       i+=1
                     else:
                       print url,"is already known..."
@@ -98,18 +99,18 @@ def index_from_file(filename):
   f = open(filename,'r')
   urls_to_process = []
   for url in f:
-    url = url.rstrip('\n')
+    url = unicode(url.rstrip('\n'))
     www_url = xowa.local_to_www(url)
     if not db.session.query(Urls).filter_by(url=www_url).all():
       urls_to_process.append(url)
-      print "...to process:",url,"..."
-    else:
-      print url,"is already known..."
+      #print "...to process:",url,"..."
+    #else:
+      #print url,"is already known..."
   return urls_to_process
 
 def index_url(urls_to_process, cache):
     for url in urls_to_process:
-        print "Indexing '{}'\n".format(url)
+        print "\nAttempting to index '{}'".format(url)
         if ".pdf" in url:
           drows = pdfparser.extract_from_url(url,cache)
         else:

--- a/pears/searcher/views.py
+++ b/pears/searcher/views.py
@@ -11,11 +11,12 @@ from . import searcher
 
 from pears import best_pears
 from pears import scorePages
-from pears.utils import read_pears, query_distribution, load_entropies
+from pears.utils import read_pears, query_distribution, load_entropies, print_timing
 
 parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
 root_dir = os.path.abspath(os.path.join(parent_dir, os.pardir))
 
+@print_timing
 def get_result_from_dht(query_dist):
     #print "Checking dht..."
     #return False
@@ -50,6 +51,7 @@ def index():
     if not query:
         return render_template("index.html")
     else:
+        #print "Making query distribution..."
         query_dist = query_distribution(query, entropies_dict)
         pear_details = []
         results = []
@@ -64,6 +66,7 @@ def index():
           scorePages.ddg_redirect(query)
         elif not pears:
             try:
+              #print "Trying to contact ip.42.pl..."
               pears = [urllib.urlopen('http://ip.42.pl/short').read().strip('\n')]
             except:
               pears = ['0.0.0.0']


### PR DESCRIPTION
Sometimes, the indexing process creates duplicate pages (a simple example is when the page was visited in its http and https versions). This code gets called at the end of indexing to get rid of redundant pages. A duplicate is defined as a page which:

* has a vector which is identical to another page's vector
* has a large url overlap with the other page (this constraint is given because sometimes, two urls with different names pointing at the same page can be useful -- see some wikipedia redirects).

Pages which are deleted from the db also have their cached version deleted.