### PR TITLE
Added pearsignore functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To know more head over to: <a href="http://aurelieherbelot.net/pears/">http://au
 
 ###Set up the development environment
 
-You can use script or the automatic installation instruc below. Automatic installation:
+You can use the install script or the automatic installation instructios below. Automatic installation:
 `$ python install.py`
 
 1. <b>Set up virtualenv</b>
@@ -64,6 +64,18 @@ You can use script or the automatic installation instruc below. Automatic instal
    then
 
    `python uncompress_db.py openvectors.dump.bz2`
+
+4. <b>Run the indexer</b>
+
+   In the root directory of the repo, run
+
+   `python indexer.py -h`
+
+   It will give instructions on how to index you browsing history.
+   The script automatically extracts your browsing history from Firefox.
+   If you use another browser, please fill a `urls.txt` text file with urls you want to index an run:
+
+   `python indexer.py --file=urls.txt`
 
 
 ###Running the PeARS search engine

--- a/README.md
+++ b/README.md
@@ -22,8 +22,11 @@ To know more head over to: <a href="http://aurelieherbelot.net/pears/">http://au
 
 ###Set up the development environment
 
-You can use the install script or the automatic installation instructios below. Automatic installation:
+You can use the install script
+
 `$ python install.py`
+
+or the installation instructions below:
 
 1. <b>Set up virtualenv</b>
     >We recommend using virtualenv for the development. If you are just here for test it out, skip to the next section.

--- a/pears/indexer/analyse_history.py
+++ b/pears/indexer/analyse_history.py
@@ -75,23 +75,19 @@ def index_history():
 def write_analysis():
   f = open(root_dir+"/userdata/history_analysis.txt",'w')
   for d in sorted(domains, key=domains.get, reverse=True):
-    f.write(d+" "+str(domains[d])+"\n") 
+    f.write(d+" "+str(domains[d])+"\n")
   f.close()
 
 def update_pearsignore(ignore_list):
   recorded_domains = []
-  f = open(root_dir+"/userdata/.pearsignore",'r')
-  for d in f:
-    d = d.rstrip('\n')
-    recorded_domains.append(d)
-  f.close()
+  with open(root_dir+"/userdata/.pearsignore",'a+') as f:
+      for d in f:
+        d = d.rstrip('\n')
+        recorded_domains.append(d)
 
-  f = open(root_dir+"/userdata/.pearsignore",'a')
-  for d in ignore_list:
-    if d not in recorded_domains:
-      f.write(d+"\n") 
-  f.close()
-  
+      for d in ignore_list:
+        if d not in recorded_domains:
+          f.write(d+"\n")
 
 def runScript(*args):
   '''Run script, either by indexing part of history or by indexing the urls

--- a/pears/indexer/analyse_history.py
+++ b/pears/indexer/analyse_history.py
@@ -1,0 +1,124 @@
+import os
+import re
+import sys
+import csv
+import sqlite3
+import numpy as np
+from urlparse import urlparse, urljoin
+#from pears.models import Urls,OpenVectors
+#from pears import db
+
+domains = {}
+home_directory = os.path.expanduser('~')
+root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir))
+if not os.path.isdir(root_dir+"/userdata/"):
+    os.makedirs(root_dir+"/userdata/")
+
+common_sites =["google", "facebook", "twitter", "duckduckgo", "yahoo", "bing"]
+
+def get_firefox_history_db(in_dir):
+  """Given a home directory it will search it for the places.sqlite file
+  in Mozilla Firefox and return the path. This should work on Windows/
+  Linux"""
+  print "Finding Firefox DB history..."
+  firefox_directory = in_dir + "/.mozilla/firefox"
+  for files in os.walk(firefox_directory):
+    # Build the filename
+    if re.search('places.sqlite', str(os.path.join(files))):
+      history_db = str(os.path.realpath(files[0]) + '/places.sqlite')
+      # print history_db
+      return history_db
+  return None
+
+def record_urls_to_process(db_urls):
+    urls_to_process = []
+    for url_str in db_urls:
+
+        url = unicode(url_str[1])
+        if not url.startswith('http'):
+            continue
+        url = url.replace('http://', 'https://').rstrip('/')
+        if "www" not in url:
+            url_with_www = url.replace("https://", "https://www.")
+            if url_with_www in urls_to_process:
+                continue
+        else:
+            url_with_www = url
+        urls_to_process.append(url)
+        url_parsed = urlparse(url)
+        netloc = url_parsed.netloc
+        if netloc in domains:
+            domains[netloc]+=1
+        else:
+            domains[netloc] = 1
+    return urls_to_process
+
+def index_history():
+  # [TODO] Set the firefox path here via config file
+  HISTORY_DB = get_firefox_history_db(home_directory)
+  if HISTORY_DB is None:
+    print 'Error - Cannot find the Firefox history database.\n\nExiting...'
+    sys.exit(1)
+
+  # connect to the sqlite history database
+  firefox_db = sqlite3.connect(HISTORY_DB)
+  cursor = firefox_db.cursor()
+
+  # get the list of all visited places via firefox browser
+  cursor.execute("SELECT * FROM 'moz_places' ORDER BY last_visit_date DESC")
+  rows = cursor.fetchall()
+
+  urls_to_process = record_urls_to_process(rows)
+  firefox_db.close()
+  return urls_to_process
+
+def write_analysis():
+  f = open(root_dir+"/userdata/history_analysis.txt",'w')
+  for d in sorted(domains, key=domains.get, reverse=True):
+    f.write(d+" "+str(domains[d])+"\n") 
+  f.close()
+
+def update_pearsignore(ignore_list):
+  recorded_domains = []
+  f = open(root_dir+"/userdata/.pearsignore",'r')
+  for d in f:
+    d = d.rstrip('\n')
+    recorded_domains.append(d)
+  f.close()
+
+  f = open(root_dir+"/userdata/.pearsignore",'a')
+  for d in ignore_list:
+    if d not in recorded_domains:
+      f.write(d+"\n") 
+  f.close()
+  
+
+def runScript(*args):
+  '''Run script, either by indexing part of history or by indexing the urls
+  provided by the user'''
+  urls_to_process = index_history()
+  write_analysis()
+  perhaps_ignore = []
+
+  for d in sorted(domains, key=domains.get, reverse=True):
+    #print d,domains[d]
+    for s in common_sites:
+      m = re.search("^"+s+"\.|\."+s+"\.",d)
+      if m:
+        perhaps_ignore.append(d)
+  print "\n\nWe suggest you put the following sites in your .pearsignore file:"
+  print perhaps_ignore
+
+  answer = raw_input("\nYou can always manually modify the .pearsignore file afterwards.\n\
+OK to populate .pearignore? (y/n)\n")
+  if answer == "y":
+      update_pearsignore(perhaps_ignore)
+
+  print "\nIn userdata/history_analysis.txt, you will find a list of domain names\n\
+from your history, sorted from the most frequently visited to the least.\n\
+We advise to transfer any entry in that file to your .pearsignore if you\n\
+don't want that domain to be indexed.\n\n\
+Your .pearsignore is found in the userdata folder."
+
+if __name__ == '__main__':
+  runScript(sys.argv)

--- a/pears/indexer/htmlparser.py
+++ b/pears/indexer/htmlparser.py
@@ -14,17 +14,18 @@ def extract_from_url(url, cache):
   drows = []
   try:
     try:
-      req = requests.get(unicode(url), allow_redirects=True, timeout=20)
-    except (requests.exceptions.SSLError or requests.exceptions.Timeout) as e:
-      #print "\nCaught the exception: {0}. Trying with http...\n".format(str(e))
-      url = unicode(url.replace("https", "http"))
-      req = requests.get(url, allow_redirects=True)
+      req = requests.get(unicode(url), allow_redirects=True, timeout=10)
     except requests.exceptions.RequestException as e:
-      #print "Ignoring {0} because of error {1}\n".format(url, str(e))
-      print "Ignoring {0} because of error...\n".format(url)
-      return
+      print "\nCaught the exception: {0}. Trying with http...\n".format(str(e))
+      try:
+        url = unicode(url.replace("https", "http"))
+        print "Attempting to index",url,"..."
+        req = requests.get(url, allow_redirects=True)
+      except:
+        print "Ignoring {0} because of error {1}\n".format(url, str(e))
+        return
     except requests.exceptions.HTTPError as err:
-      #print str(err)
+      print "ERROR",str(err)
       return
     req.encoding = 'utf-8'
     if req.status_code is not 200:

--- a/pears/scorePages.py
+++ b/pears/scorePages.py
@@ -134,6 +134,7 @@ def runScript(query, query_dist, pears):
     url_titles = {}
     best_urls = []
     for pear in pears:
+        print pear
         pear_urls = get_pear_urls(pear)
         document_scores, wordclouds, titles = scoreDocs(query, query_dist, pear_urls)	#with URL overlap
         #document_scores, wordclouds = scoreDS(query_dist, pear_urls)  # without URL overlap

--- a/roadmap.md
+++ b/roadmap.md
@@ -1,0 +1,12 @@
+## Roadmap for PeARS V1.0
+
+
+> WIP. Feel free to add the features necessary for the release
+
+## PeARS scope of the fist release:
+
+1. We not have a semi-working DHT implementation. The current implementaion does not go well with the Flask app we have since the twisted I use is asynchronous communication and Flask itself is synchronous. This is to be replaced with a better implementation preferably in a different language that deals with concurrency and distribution a bit better. The language I propose for our DHT is Elixir and it has a minimal chord DHT implementation which can be used. Things to be implemented so as to integrate with PeARS are:
+    * K-nearest node search.
+    * Distributed locality sensitive hashing for better search results on the DHT.
+    * Setup a stun server to do proper TCP/UDP packet relay.
+


### PR DESCRIPTION
I've added *pears/indexer/analyse_history.py*, which should be run upon install.  This analyses the user's history, producing a new folder *userdata/* with:

* a *history_analysis.txt* file, which shows which domains have been visited and how many times, ordered by visit frequency;
* a *.pearsignore* file which, given the user's agreement, will have some domains from the usual suspects (search engines, facebook, etc).

Any domain in the *.pearsignore* file will be ignored when indexing. The user is encouraged to study their *history_analysis.txt* file to add whichever other domain they don't want to index to their *.pearsignore*.

